### PR TITLE
adding more metadata for gem

### DIFF
--- a/mailpace-rails.gemspec
+++ b/mailpace-rails.gemspec
@@ -14,6 +14,9 @@ Gem::Specification.new do |spec|
   spec.description = "The MailPace Rails Gem is a plug in for ActionMailer to send emails via MailPace to make sending emails from Rails apps super simple."
   spec.license     = "MIT"
 
+  spec.metadata['source_code_uri'] = 'https://github.com/mailpace/mailpace-rails'
+  spec.metadata['changelog_uri'] = 'https://github.com/mailpace/mailpace-rails/blob/master/CHANGELOG.md'
+
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency('actionmailer', ">= 6.0.0")


### PR DESCRIPTION
Hey!

I always look up all information about gems in rubygem.org website, but you seem to be missing couple of critical links in metadata. I think it would make life easier for some people, if those would be available.

If this will get merged link for source code and changelog appear on rubygems.org