### PR TITLE
Support names in to and reply to headers

### DIFF
--- a/lib/mailpace-rails.rb
+++ b/lib/mailpace-rails.rb
@@ -22,7 +22,7 @@ module Mailpace
         'https://app.mailpace.com/api/v1/send',
         body: {
           from: address_list(mail.header[:from])&.addresses&.first.to_s,
-          to: mail.to.join(','),
+          to: address_list(mail.header[:to])&.addresses&.join(','),
           subject: mail.subject,
           htmlbody: mail.html_part ? mail.html_part.body.decoded : mail.body.to_s,
           textbody: if mail.multipart?

--- a/lib/mailpace-rails.rb
+++ b/lib/mailpace-rails.rb
@@ -30,7 +30,7 @@ module Mailpace
                     end,
           cc: address_list(mail.header[:cc])&.addresses&.join(','),
           bcc: address_list(mail.header[:bcc])&.addresses&.join(','),
-          replyto: mail.reply_to&.join(','),
+          replyto: address_list(mail.header[:reply_to])&.addresses&.join(','),
           inreplyto: mail.header['In-Reply-To'].to_s,
           references: mail.header['References'].to_s,
           list_unsubscribe: mail.header['list_unsubscribe'].to_s,

--- a/test/dummy/app/mailers/full_name_mailer.rb
+++ b/test/dummy/app/mailers/full_name_mailer.rb
@@ -1,6 +1,6 @@
 class FullNameMailer < ApplicationMailer
   default from: 'My Full Name <notifications@example.com>',
-          to: 'fake@sdfasdfsdaf.com'
+          to: 'Recipient Full Name <fake@sdfasdfsdaf.com>'
 
   def full_name_email
     mail

--- a/test/mailpace/mailer_test.rb
+++ b/test/mailpace/mailer_test.rb
@@ -163,14 +163,14 @@ class Mailpace::Rails::Test < ActiveSupport::TestCase
   # See https://github.com/mikel/mail/blob/22a7afc23f253319965bf9228a0a430eec94e06d/lib/mail/fields/reply_to_field.rb
   test 'supports reply to' do
     t = TestMailer.welcome_email
-    t.reply_to = 'This will be stripped <reply@test.com>'
+    t.reply_to = 'Reply To Name <reply@test.com>'
     t.deliver!
 
     assert_requested(
       :post, 'https://app.mailpace.com/api/v1/send',
       times: 1
     ) do |req|
-      JSON.parse(req.body)['replyto'] == 'reply@test.com'
+      JSON.parse(req.body)['replyto'] == 'Reply To Name <reply@test.com>'
     end
   end
 

--- a/test/mailpace/mailer_test.rb
+++ b/test/mailpace/mailer_test.rb
@@ -94,6 +94,18 @@ class Mailpace::Rails::Test < ActiveSupport::TestCase
     end
   end
 
+  test 'supports full names in the to address' do
+    t = FullNameMailer.full_name_email
+    t.deliver!
+
+    assert_requested(
+      :post, 'https://app.mailpace.com/api/v1/send',
+      times: 1
+    ) do |req|
+      JSON.parse(req.body)['to'] == 'Recipient Full Name <fake@sdfasdfsdaf.com>'
+    end
+  end
+
   test 'supports single tag' do
     t = TagMailer.single_tag
     t.deliver!


### PR DESCRIPTION
This changes the behaviour of the mailpace gem to match the behaviour of the server.

The documentation indicates that [names in the "To" field are supported](https://docs.mailpace.com/reference/send#body-parameters), but currently they are stripped. The gem should not strip these.

This change also enables providing more than a single Reply-To address (with names), which the Mailpace server also currently supports (I checked!), despite [the documentation implying otherwise](https://docs.mailpace.com/reference/send#body-parameters). The prior test suggested that names in the Reply-To header would be stripped, but this is not currently true in production (I checked).