### PR TITLE
Send text-only email if not multipart and content-type is text/plain

### DIFF
--- a/lib/mailpace-rails.rb
+++ b/lib/mailpace-rails.rb
@@ -17,6 +17,15 @@ module Mailpace
     end
 
     def deliver!(mail)
+      if mail.multipart?
+        htmlbody = mail.html_part.body.decoded,
+        textbody = mail.text_part.body.decoded
+      elsif mail.mime_type == "text/plain"
+        textbody = mail.body.to_s
+      else
+        htmlbody = mail.body.to_s
+      end
+
       check_delivery_params(mail)
       result = HTTParty.post(
         'https://app.mailpace.com/api/v1/send',
@@ -24,10 +33,8 @@ module Mailpace
           from: address_list(mail.header[:from])&.addresses&.first.to_s,
           to: address_list(mail.header[:to])&.addresses&.join(','),
           subject: mail.subject,
-          htmlbody: mail.html_part ? mail.html_part.body.decoded : mail.body.to_s,
-          textbody: if mail.multipart?
-                      mail.text_part ? mail.text_part.body.decoded : nil
-                    end,
+          htmlbody:,
+          textbody:,
           cc: address_list(mail.header[:cc])&.addresses&.join(','),
           bcc: address_list(mail.header[:bcc])&.addresses&.join(','),
           replyto: address_list(mail.header[:reply_to])&.addresses&.join(','),

--- a/test/dummy/app/mailers/plaintext_mailer.rb
+++ b/test/dummy/app/mailers/plaintext_mailer.rb
@@ -1,0 +1,8 @@
+class PlaintextMailer < ApplicationMailer
+  default from: 'notifications@example.com',
+          to: 'fake@sdfasdfsdaf.com'
+
+  def plain_only_email
+    mail
+  end
+end

--- a/test/dummy/app/views/plaintext_mailer/plain_only_email.text.erb
+++ b/test/dummy/app/views/plaintext_mailer/plain_only_email.text.erb
@@ -1,0 +1,1 @@
+test text only

--- a/test/mailpace/mailer_test.rb
+++ b/test/mailpace/mailer_test.rb
@@ -276,4 +276,18 @@ class Mailpace::Rails::Test < ActiveSupport::TestCase
       req.headers['Idempotency-Key'].nil?
     end
   end
+
+  test 'supports text-only emails' do
+    t = PlaintextMailer.plain_only_email
+    t.references = '<message-id@test.com> <message-id2@test.com>'
+    t.deliver!
+
+    assert_requested(
+      :post, 'https://app.mailpace.com/api/v1/send',
+      times: 1
+    ) do |req|
+      JSON.parse(req.body)['htmlbody'].nil? &&
+        JSON.parse(req.body)['textbody'] == "test text only\n"
+    end
+  end
 end


### PR DESCRIPTION
I have a problem where my text/plain emails are being sent out as multipart/mixed, with the plain text wrapped in `<html></html>`. This only happens in production.

I've isolated the problem to this gem, which always uses `htmlbody` when only one part is present, irrespective of content type.

This PR determines which part to send based on `mime_type`.